### PR TITLE
Added only_cancel_run_if_commit_is_using_pr_branch option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,14 @@ inputs:
     description: the host url used for the dbt Cloud account, by default cloud.getdbt.com is used
     required: false
     default: "cloud.getdbt.com"
+  only_cancel_run_if_commit_is_using_pr_branch:
+     description: "A flag that can be set to True or False. If set to true the action will only cancel runs that are based on the same pr"
+    required: false
+    default: "False"
+  github_repo_token: 
+    description: "A GitHub token for API access - required if only_cancel_run_if_commit_is_using_pr_branch is set to True"
+    required: false
+
 outputs:
   cancelled_jobs_flag:
     description: "Returns True if a job or jobs was cancelled, False is no jobs were cancelled"

--- a/main.py
+++ b/main.py
@@ -18,6 +18,20 @@ dbt_cloud_job_id = os.environ["INPUT_DBT_CLOUD_JOB_ID"]
 # setting the job_check_interval
 dbt_cloud_host = os.environ.get('INPUT_DBT_CLOUD_HOST', 'cloud.getdbt.com')
 
+# getting the flag only_cancel_run_if_commit_is_using_pr_branch 
+same_branch_flag = os.environ.get('INPUT_ONLY_CANCEL_RUN_IF_COMMIT_IS_USING_PR_BRANCH', 'False')
+
+# getting the github api token - if only_cancel_run_if_commit_is_using_pr_branch ss set to True, this is used
+github_api_token = "token " + os.environ.get('INPUT_GITHUB_REPO_TOKEN', 'not_needed')
+
+# getting the name of the github branch the PR is on - if only_cancel_run_if_commit_is_using_pr_branch ss set to True, this is used
+pr_branch_name = os.environ.get('GITHUB_HEAD_REF', 'a_branch_name')
+
+# getting the name of the github repo the PR is on - if only_cancel_run_if_commit_is_using_pr_branch is set to True, this is used
+pr_repo_name = os.environ.get('GITHUB_REPOSITORY', 'a_repo_name')
+
+
+
 # ------------------------------------------------------------------------------
 # use environment variables to set dbt cloud api configuration
 # ------------------------------------------------------------------------------
@@ -38,6 +52,21 @@ run_status_map = {
   20: 'Error',
   30: 'Cancelled',
 }
+
+# -----------------------------------------------------------------------------------------------------
+# setting a function to take the returned sha from the dbt cloud api and look up the GitHub branch name
+# only used if only_cancel_run_if_commit_is_using_pr_branch is set to True
+# -----------------------------------------------------------------------------------------------------
+
+def get_github_branch_from_dbt_run_sha(sha, repo, github_token):
+    
+    headers = {'Authorization': github_token}
+    
+    github_api_url = f"https://api.github.com/repos/{repo}/commits/{sha}/pulls"
+    
+    sha_info = requests.get(github_api_url, headers=headers).json()
+    
+    return sha_info[0]['head']['ref']
 
 # ------------------------------------------------------------------------------
 # setting a function to return the most recent runs for a given job
@@ -66,9 +95,26 @@ def get_recent_runs_for_job(base_url, headers, job_id):
         
         # getting run url 
         run_url = run["href"]
+
+        # getting the git sha
+        run_git_sha = run['git_sha']
+
+        # if the same branch flag is set to true we look up the name of the github branch the run was triggered on
+        if same_branch_flag == "True" and run_git_sha != None:
+        
+            # getting the github branch name of the run using the get_github_branch_from_dbt_run_sha function
+            run_github_branch_name = get_github_branch_from_dbt_run_sha(run_git_sha, pr_repo_name, github_api_token)
+
+            print(run_github_branch_name)
+            
+        # if it's set to False we use a dummy branch name
+        else:
+            
+            # setting a (somewhat) dummy branch name
+            run_github_branch_name = f"branch relating to sha: {run_git_sha}"
         
         # appending the elements to the list
-        recent_runs_info.append({"run_id" : run_id, "run_status" : run_status, "run_url" : run_url })
+        recent_runs_info.append({"run_id" : run_id, "run_status" : run_status, "run_url" : run_url, "run_git_sha" : run_git_sha, "run_github_branch_name" : run_github_branch_name })
 
     return recent_runs_info
 
@@ -107,6 +153,12 @@ def main():
 
     # creating a list to collect all cancelled runs
     cancelled_runs = []
+
+    # if the same_branch_flag is True we filter to just runs on the same branch as the PR
+    if same_branch_flag == "True":
+
+        # rebuilding the list with just runs with the same branch
+        most_recent_runs = [run for run in most_recent_runs if run['run_github_branch_name'] == pr_branch_name]
 
     # looping the returned run, if there is some running or qued jobs, we cancel them in order to allow the most recent job to kick off
     for run in most_recent_runs:

--- a/main.py
+++ b/main.py
@@ -31,7 +31,6 @@ pr_branch_name = os.environ.get('GITHUB_HEAD_REF', 'a_branch_name')
 pr_repo_name = os.environ.get('GITHUB_REPOSITORY', 'a_repo_name')
 
 
-
 # ------------------------------------------------------------------------------
 # use environment variables to set dbt cloud api configuration
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added a flag for `only_cancel_run_if_commit_is_using_pr_branch` 

The user can set this flag to either `True` or `False` - by default this is set to `False` 

This flag will enforce the Github Action to only cancel a given CI run if the CI run is using the same branch as the Pull Request
