### PR TITLE
Enable parsing PR number from dbt Cloud run's schema_override parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ___
 - `only_cancel_queued_starting_run` - A flag that can be set to `true` or `false`
   - When this flag is set to `true`, the action will only cancel dbt Cloud job runs that are in the state `Queued` or `Starting`
   - The purpose of this flag is to prevent the action from cancelling jobs that are already running when a new CI job is kicked off. Some use cases require this as they don't want to cancel a job that is halfway completed
-`cancel_runs_based_on_schema_override` - A flag that can be set to `true` or `false`
+- `cancel_runs_based_on_schema_override` - A flag that can be set to `true` or `false`
   - When this and `only_cancel_run_if_commit_is_using_pr_branch` are both set to `true`, this action will find the associated PR number of existing dbt runs based on their `schema_override`. Specifically it assumes the `schema_override` will be of the form `dbt_cloud_pr_{dbt_cloud_job_id}_{github_pr_number}`, which matches that of dbt Cloud CI.
   - The purpose of this flag is to enable canceling stale CI runs even if they weren't triggered directly by the dbt Cloud <> GitHub integration. For example, teams triggering CI jobs via GitHub Actions (or any other CI/CD tool) can still utilize this action, as long as the `schema_override` parameter is configured properly in the CI job.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ ___
 - `only_cancel_queued_starting_run` - A flag that can be set to `true` or `false`
   - When this flag is set to `true`, the action will only cancel dbt Cloud job runs that are in the state `Queued` or `Starting`
   - The purpose of this flag is to prevent the action from cancelling jobs that are already running when a new CI job is kicked off. Some use cases require this as they don't want to cancel a job that is halfway completed
+`cancel_runs_based_on_schema_override` - A flag that can be set to `true` or `false`
+  - When this and `only_cancel_run_if_commit_is_using_pr_branch` are both set to `true`, this action will find the associated PR number of existing dbt runs based on their `schema_override`. Specifically it assumes the `schema_override` will be of the form `dbt_cloud_pr_{dbt_cloud_job_id}_{github_pr_number}`, which matches that of dbt Cloud CI.
+  - The purpose of this flag is to enable canceling stale CI runs even if they weren't triggered directly by the dbt Cloud <> GitHub integration. For example, teams triggering CI jobs via GitHub Actions (or any other CI/CD tool) can still utilize this action, as long as the `schema_override` parameter is configured properly in the CI job.
 
 It's recommend to pass sensitive variables as GitHub secrets. [Example article on how to use Github Action secrets](https://www.theserverside.com/blog/Coffee-Talk-Java-News-Stories-and-Opinions/GitHub-Actions-Secrets-Example-Token-Tutorial)
 

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,13 @@ inputs:
     description: if set to true, this will only cancel runs in the state of Queued or Starting
     required: false
     default: false
+  cancel_runs_based_on_schema_override:
+    description: |
+      if this and `only_cancel_run_if_commit_is_using_pr_branch` are both set to true, 
+      the action will parse the PR number from existing dbt Cloud runs based on their `schema_override`,
+      which is expected to follow the format `dbt_cloud_pr_{dbt_cloud_job_id}_{github_pr_number}` (matching dbt Cloud CI).
+    required: false
+    default: false
 
 outputs:
   cancelled_jobs_flag:

--- a/main.py
+++ b/main.py
@@ -81,6 +81,8 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
         # checking if the same branch flag is set to true
         if same_branch_flag == "true":
 
+            subprocess.call('echo "CURRENT_RUN={}"'.format(run), shell=True)
+
             if use_schema_override_flag == "true":
 
                 # grabbing the schema override to parse PR number when CI is triggered by external process
@@ -93,6 +95,8 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
                 # grabbing the pr number from the dbt Cloud job run
                 run_git_pr_number = run['trigger']['github_pull_request_id']
             
+            subprocess.call('echo "CURRENT_RUN_PR={}"'.format(run_git_pr_number), shell=True)
+
             # making sure the pr number isn't none before comparing to pr_branch_number
             if run_git_pr_number != None:
 

--- a/main.py
+++ b/main.py
@@ -81,7 +81,7 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
         # checking if the same branch flag is set to true
         if same_branch_flag == "true":
 
-            subprocess.call('echo "CURRENT_RUN={}"'.format(run), shell=True)
+            subprocess.call('echo "CURRENT_RUN={}"'.format(run['trigger']), shell=True)
 
             if use_schema_override_flag == "true":
 
@@ -89,6 +89,8 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
                 run_schema_override = run['trigger']['schema_override']
                 schema_override_prefix = f'dbt_cloud_pr_{str(job_id)}_'
                 run_git_pr_number = None if run_schema_override is None or not run_schema_override.isnumeric() else int(run_schema_override.lstrip(schema_override_prefix))
+
+                subprocess.call('echo "Using schema flag"', shell=True)
             
             else:
 

--- a/main.py
+++ b/main.py
@@ -88,9 +88,9 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
                 # grabbing the schema override to parse PR number when CI is triggered by external process
                 run_schema_override = run['trigger']['schema_override']
                 schema_override_prefix = f'dbt_cloud_pr_{str(job_id)}_'
-                run_git_pr_number = None if run_schema_override is None or not run_schema_override.isnumeric() else int(run_schema_override.lstrip(schema_override_prefix))
-
-                subprocess.call('echo "Using schema flag"', shell=True)
+                run_git_pr_number = None if run_schema_override is None else run_schema_override.lstrip(schema_override_prefix)
+                # defaulting to not canceling the job if run_git_pr_number isn't an integer
+                run_git_pr_number = None if not run_git_pr_number.isnumeric() else int(run_git_pr_number)
             
             else:
 

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
                 schema_override_prefix = f'dbt_cloud_pr_{str(job_id)}_'
                 run_git_pr_number = None if run_schema_override is None else run_schema_override.lstrip(schema_override_prefix)
                 # defaulting to not canceling the job if run_git_pr_number isn't an integer
-                run_git_pr_number = None if not run_git_pr_number.isnumeric() else int(run_git_pr_number)
+                run_git_pr_number = None if run_git_pr_number is None or not run_git_pr_number.isnumeric() else int(run_git_pr_number)
             
             else:
 

--- a/main.py
+++ b/main.py
@@ -86,7 +86,7 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
                 # grabbing the schema override to parse PR number when CI is triggered by external process
                 run_schema_override = run['trigger']['schema_override']
                 schema_override_prefix = f'dbt_cloud_pr_{str(job_id)}_'
-                run_git_pr_number = None if run_schema_override is None else run_schema_override.lstrip(schema_override_prefix)
+                run_git_pr_number = None if run_schema_override is None or not run_schema_override.isnumeric() else int(run_schema_override.lstrip(schema_override_prefix))
             
             else:
 

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ pr_branch_number = os.environ.get("INPUT_GITHUB_PR_NUMBER", 'none')
 only_queued_starting = os.environ.get("INPUT_ONLY_CANCEL_QUEUED_STARTING_RUN", 'false')
 
 # getting the flag cancel_runs_based_on_schema_override
-use_schema_override_flag = os.environ.get("cancel_runs_based_on_schema_override", 'false')
+use_schema_override_flag = os.environ.get("INPUT_CANCEL_RUNS_BASED_ON_SCHEMA_OVERRIDE", 'false')
 
 # ------------------------------------------------------------------------------
 # use environment variables to set dbt cloud api configuration

--- a/main.py
+++ b/main.py
@@ -81,8 +81,6 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
         # checking if the same branch flag is set to true
         if same_branch_flag == "true":
 
-            subprocess.call('echo "CURRENT_RUN={}"'.format(run['trigger']), shell=True)
-
             if use_schema_override_flag == "true":
 
                 # grabbing the schema override to parse PR number when CI is triggered by external process
@@ -96,8 +94,6 @@ def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema
 
                 # grabbing the pr number from the dbt Cloud job run
                 run_git_pr_number = run['trigger']['github_pull_request_id']
-            
-            subprocess.call('echo "CURRENT_RUN_PR={}"'.format(run_git_pr_number), shell=True)
 
             # making sure the pr number isn't none before comparing to pr_branch_number
             if run_git_pr_number != None:

--- a/main.py
+++ b/main.py
@@ -33,6 +33,8 @@ pr_branch_number = os.environ.get("INPUT_GITHUB_PR_NUMBER", 'none')
 # one note on this is in YAML it's passed as a bool aka true and in python it comes in as a string
 only_queued_starting = os.environ.get("INPUT_ONLY_CANCEL_QUEUED_STARTING_RUN", 'false')
 
+# getting the flag cancel_runs_based_on_schema_override
+use_schema_override_flag = os.environ.get("cancel_runs_based_on_schema_override", 'false')
 
 # ------------------------------------------------------------------------------
 # use environment variables to set dbt cloud api configuration
@@ -59,7 +61,7 @@ run_status_map = {
 # creating a function that takes the recent runs and filters them down depending on the same branch flag
 # -------------------------------------------------------------------------------------------------------
 
-def extract_dbt_runs_info(recent_runs_list, same_branch_flag):
+def extract_dbt_runs_info(recent_runs_list, job_id, same_branch_flag, use_schema_override_flag):
     
     # setting an empty list to populate with run_ids and statuses
     recent_runs_info = []
@@ -79,8 +81,17 @@ def extract_dbt_runs_info(recent_runs_list, same_branch_flag):
         # checking if the same branch flag is set to true
         if same_branch_flag == "true":
 
-            # grabbing the pr number from the dbt Cloud job run
-            run_git_pr_number = run['trigger']['github_pull_request_id']
+            if use_schema_override_flag == "true":
+
+                # grabbing the schema override to parse PR number when CI is triggered by external process
+                run_schema_override = run['trigger']['schema_override']
+                schema_override_prefix = f'dbt_cloud_pr_{str(job_id)}_'
+                run_git_pr_number = None if run_schema_override is None else run_schema_override.lstrip(schema_override_prefix)
+            
+            else:
+
+                # grabbing the pr number from the dbt Cloud job run
+                run_git_pr_number = run['trigger']['github_pull_request_id']
             
             # making sure the pr number isn't none before comparing to pr_branch_number
             if run_git_pr_number != None:
@@ -110,7 +121,7 @@ def extract_dbt_runs_info(recent_runs_list, same_branch_flag):
 # setting a function to return the most recent runs for a given job
 # ------------------------------------------------------------------------------
 
-def get_recent_runs_for_job(base_url, headers, job_id, same_branch_flag, max_runs):
+def get_recent_runs_for_job(base_url, headers, job_id, same_branch_flag, max_runs, use_schema_override_flag):
 
     # setting the request url
     dbt_cloud_runs_url = f'{base_url}/runs/?job_definition_id={job_id}&order_by=-id&include_related=["trigger"]&limit={max_runs}'
@@ -120,7 +131,7 @@ def get_recent_runs_for_job(base_url, headers, job_id, same_branch_flag, max_run
     recent_runs = requests.get(dbt_cloud_runs_url, headers=headers, timeout=30).json()
     
     # using the function extract the recent runs
-    recent_runs_info = extract_dbt_runs_info(recent_runs['data'], same_branch_flag)
+    recent_runs_info = extract_dbt_runs_info(recent_runs['data'], job_id, same_branch_flag, use_schema_override_flag)
 
     return recent_runs_info
 
@@ -156,7 +167,7 @@ def main():
     time.sleep(10)
 
     # getting the most recent runs of the given job
-    most_recent_runs = get_recent_runs_for_job(base_url=base_dbt_cloud_api_url, headers=req_auth_headers, job_id=dbt_cloud_job_id, same_branch_flag=same_branch_flag, max_runs=max_runs)
+    most_recent_runs = get_recent_runs_for_job(base_url=base_dbt_cloud_api_url, headers=req_auth_headers, job_id=dbt_cloud_job_id, same_branch_flag=same_branch_flag, max_runs=max_runs, use_schema_override_flag=use_schema_override_flag)
 
     # creating a list to collect all cancelled runs
     cancelled_runs = []


### PR DESCRIPTION
This action works great for jobs triggered directly from the dbt Cloud <> GitHub integration. But teams may want to trigger CI jobs on dbt Cloud using other CI/CD tools like GitHub Actions. For these cases, since the dbt API won't populate the PR number, this PR adds an option to parse the PR # from the `schema_override` parameter in each dbt Cloud run. 